### PR TITLE
fix: function's returns are missing

### DIFF
--- a/static/styles/jsdoc-default.css
+++ b/static/styles/jsdoc-default.css
@@ -504,9 +504,7 @@ footer {
    max-width: 800px;
 }
 
-.params,
-.returns,
-.props {
+.params, .returns, .props {
     border-spacing: 0;
     border: 1px solid #ddd;
     border-radius: 3px;

--- a/static/styles/jsdoc-default.css
+++ b/static/styles/jsdoc-default.css
@@ -1,569 +1,606 @@
 * {
-    box-sizing: border-box
+  box-sizing: border-box
 }
 
-html, body {
-    height: 100%;
-    width: 100%;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    color: #3e3c42;
-    text-rendering: optimizeLegibility;
-    margin: 0;
+html,
+body {
+  height: 100%;
+  width: 100%;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  color: #3e3c42;
+  text-rendering: optimizeLegibility;
+  margin: 0;
 }
 
 body {
-    color: #3e3c42;
-    background-color: #f3f3f3;
-    width: 100%;
-    font: 16px/1.875 "Avenir Next W01", "Avenir Next", "Helvetica Neue", Helvetica, sans-serif;
-    font-size: 16px;
-    line-height: 160%;
+  color: #3e3c42;
+  background-color: #f3f3f3;
+  width: 100%;
+  font: 16px/1.875 "Avenir Next W01", "Avenir Next", "Helvetica Neue", Helvetica, sans-serif;
+  font-size: 16px;
+  line-height: 160%;
 }
 
-a, a:active {
-    color: #0095dd;
-    text-decoration: none;
+a,
+a:active {
+  color: #0095dd;
+  text-decoration: none;
 }
 
 a:hover {
-    text-decoration: underline
+  text-decoration: underline
 }
 
-p, ul, ol, blockquote {
-    margin-bottom: 1em;
+p,
+ul,
+ol,
+blockquote {
+  margin-bottom: 1em;
 }
 
 p {
-    max-width: 800px;
+  max-width: 800px;
 }
 
-h1, h2, h3, h4, h5, h6 {
-    color: #706d77;
-    font-weight: 500;
-    margin: 0;
-    line-height: 1;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: #706d77;
+  font-weight: 500;
+  margin: 0;
+  line-height: 1;
 }
 
 h1 {
-    color: #4b484f;
-    font-weight: 500;
-    font-size: 40px;
-    display: block;
+  color: #4b484f;
+  font-weight: 500;
+  font-size: 40px;
+  display: block;
 }
 
 h1 span {
-    color: #999;
-    font-size: 32px;
-    display: block;
-    line-height: 1.5;
+  color: #999;
+  font-size: 32px;
+  display: block;
+  line-height: 1.5;
 }
 
 h1.page-title {
-    border-bottom: 1px dashed #ccc;
-    margin-bottom: 20px;
-    padding-bottom: 30px;
+  border-bottom: 1px dashed #ccc;
+  margin-bottom: 20px;
+  padding-bottom: 30px;
 }
 
 h2 {
-    font-size: 30px;
-    margin: 1.5em 0 0;
+  font-size: 30px;
+  margin: 1.5em 0 0;
 }
 
 h3 {
-    font-size: 20px;
-    margin: 1.5em 0 0;
-    text-transform: uppercase;
+  font-size: 20px;
+  margin: 1.5em 0 0;
+  text-transform: uppercase;
 }
 
 h3.reference-title {
-    display: block;
-    font-weight: 400;
-    margin-top: 2em;
-    max-width: 200px;
+  display: block;
+  font-weight: 400;
+  margin-top: 2em;
+  max-width: 200px;
 }
 
 h3.reference-title small {
-    display: inline-block;
-    color: #0095dd;
-    margin-left: 5px;
-    font-weight: 500;
+  display: inline-block;
+  color: #0095dd;
+  margin-left: 5px;
+  font-weight: 500;
 }
 
 h3.subsection-title {
-    border-bottom: 1px solid #ececec;
-    padding-bottom: 20px;
-    margin-top: 3em;
-    margin-bottom: 1em;
+  border-bottom: 1px solid #ececec;
+  padding-bottom: 20px;
+  margin-top: 3em;
+  margin-bottom: 1em;
 }
 
 h4 {
-    font-size: 16px;
-    margin: 1em 0 0;
-    font-weight: bold;
+  font-size: 16px;
+  margin: 1em 0 0;
+  font-weight: bold;
 }
 
 h4.name {
-    font-size: 20px;
-    margin-top: 0;
-    font-weight: 500;
+  font-size: 20px;
+  margin-top: 0;
+  font-weight: 500;
 }
 
 h5 {
-    margin: 2em 0 0.5em 0;
-    font-size: 14px;
-    font-weight: 500;
-    text-transform: uppercase;
+  margin: 2em 0 0.5em 0;
+  font-size: 14px;
+  font-weight: 500;
+  text-transform: uppercase;
 }
 
 .container-overview .subsection-title {
-    font-size: 14px;
-    text-transform: uppercase;
-    margin: 8px 0 15px 0;
-    font-weight: bold;
-    color: #4D4E53;
-    padding-top: 10px;
+  font-size: 14px;
+  text-transform: uppercase;
+  margin: 8px 0 15px 0;
+  font-weight: bold;
+  color: #4D4E53;
+  padding-top: 10px;
 }
 
 h6 {
-    font-size: 100%;
-    letter-spacing: -0.01em;
-    margin: 6px 0 3px 0;
-    font-style: italic;
-    text-transform: uppercase;
-    font-weight: 500;
+  font-size: 100%;
+  letter-spacing: -0.01em;
+  margin: 6px 0 3px 0;
+  font-style: italic;
+  text-transform: uppercase;
+  font-weight: 500;
 }
 
-tt, code, kbd, samp {
-    font-family: "Source Code Pro", monospace;
-    background: #f4f4f4;
-    padding: 1px 5px;
-    border-radius: 5px;
+tt,
+code,
+kbd,
+samp {
+  font-family: "Source Code Pro", monospace;
+  background: #f4f4f4;
+  padding: 1px 5px;
+  border-radius: 5px;
 }
 
 .class-description {
-    margin-bottom: 1em;
-    margin-top: 1em;
-    padding: 10px 20px;
-    background-color: rgba(26, 159, 224, 0.1);
+  margin-bottom: 1em;
+  margin-top: 1em;
+  padding: 10px 20px;
+  background-color: rgba(26, 159, 224, 0.1);
 }
 
 .class-description:empty {
-    margin: 0
+  margin: 0
 }
 
 #main {
-    background-color: white;
-    float: right;
-    min-width: 360px;
-    width: calc(100% - 300px);
-    padding: 30px;
-    z-index: 100;
+  background-color: white;
+  float: right;
+  min-width: 360px;
+  width: calc(100% - 300px);
+  padding: 30px;
+  z-index: 100;
 }
 
 header {
-    display: block;
-    max-width: 1400px;
+  display: block;
+  max-width: 1400px;
 }
 
 section {
-    display: block;
-    max-width: 1400px;
-    background-color: #fff;
+  display: block;
+  max-width: 1400px;
+  background-color: #fff;
 }
 
 .variation {
-    display: none
+  display: none
 }
 
 .signature-attributes {
-    font-size: 60%;
-    color: #aaa;
-    font-style: italic;
-    font-weight: lighter;
+  font-size: 60%;
+  color: #aaa;
+  font-style: italic;
+  font-weight: lighter;
 }
 
 .rule {
-    width: 100%;
-    margin-top: 20px;
-    display: block;
-    border-top: 1px solid #ccc;
+  width: 100%;
+  margin-top: 20px;
+  display: block;
+  border-top: 1px solid #ccc;
 }
 
 ul {
-    list-style-type: none;
-    padding-left: 0;
+  list-style-type: none;
+  padding-left: 0;
 }
 
 ul li a {
-    font-weight: 500;
+  font-weight: 500;
 }
 
 ul ul {
-    padding-top: 5px;
+  padding-top: 5px;
 }
 
 ul li ul {
-    padding-left: 20px;
+  padding-left: 20px;
 }
 
 ul li ul li a {
-    font-weight: normal;
+  font-weight: normal;
 }
 
 nav {
-    float: left;
-    display: block;
-    width: 300px;
-    background: #f7f7f7;
-    overflow-x: visible;
-    overflow-y: auto;
-    height: 100%;
-    padding: 0px 30px 100px 30px;
-    height: 100%;
-    position: fixed;
-    transition: left 0.2s;
-    z-index: 998;
-    margin-top: 0px;
-    top: 43px;
+  float: left;
+  display: block;
+  width: 300px;
+  background: #f7f7f7;
+  overflow-x: visible;
+  overflow-y: auto;
+  height: 100%;
+  padding: 0px 30px 100px 30px;
+  height: 100%;
+  position: fixed;
+  transition: left 0.2s;
+  z-index: 998;
+  margin-top: 0px;
+  top: 43px;
 }
 
 .navicon-button {
-    display: inline-block;
-    position: fixed;
-    bottom: 1.5em;
-    right: 1.5em;
-    z-index: 2;
+  display: inline-block;
+  position: fixed;
+  bottom: 1.5em;
+  right: 1.5em;
+  z-index: 2;
 }
 
 nav h3 {
-    font-size: 13px;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    font-weight: bold;
-    line-height: 24px;
-    margin: 40px 0 10px 0;
-    padding: 0;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-weight: bold;
+  line-height: 24px;
+  margin: 40px 0 10px 0;
+  padding: 0;
 }
 
 nav ul {
-    font-size: 100%;
-    line-height: 17px;
-    padding: 0;
-    margin: 0;
-    list-style-type: none;
-    border: none;
-    padding-left: 0;
+  font-size: 100%;
+  line-height: 17px;
+  padding: 0;
+  margin: 0;
+  list-style-type: none;
+  border: none;
+  padding-left: 0;
 }
 
 nav ul a {
-    font-size: 16px;
+  font-size: 16px;
 }
 
-nav ul a, nav ul a:active {
-    display: block;
+nav ul a,
+nav ul a:active {
+  display: block;
 }
 
-nav ul a:hover, nav ul a:active {
-    color: hsl(200, 100%, 43%);
-    text-decoration: none;
+nav ul a:hover,
+nav ul a:active {
+  color: hsl(200, 100%, 43%);
+  text-decoration: none;
 }
 
 nav>ul {
-    padding: 0 10px;
+  padding: 0 10px;
 }
 
 nav>ul li:first-child {
-    padding-top: 0;
+  padding-top: 0;
 }
 
 nav ul li ul {
-    padding-left: 0;
+  padding-left: 0;
 }
 
 nav>ul>li {
-    border-bottom: 1px solid #e2e2e2;
-    padding: 10px 0 20px 0;
+  border-bottom: 1px solid #e2e2e2;
+  padding: 10px 0 20px 0;
 }
 
 nav>ul>li.active ul {
-    border-left: 3px solid #0095dd;
-    padding-left: 15px;
+  border-left: 3px solid #0095dd;
+  padding-left: 15px;
 }
 
 nav>ul>li.active ul li.active a {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 nav>ul>li.active a {
-    color: #0095dd;
+  color: #0095dd;
 }
 
 nav>ul>li>a {
-    color: #706d77;
-    padding: 20px 0;
-    font-size: 18px;
+  color: #706d77;
+  padding: 20px 0;
+  font-size: 18px;
 }
 
 nav ul ul {
-    margin-bottom: 10px;
-    padding-left: 0;
+  margin-bottom: 10px;
+  padding-left: 0;
 }
 
 nav ul ul a {
-    color: #5f5c63;
+  color: #5f5c63;
 }
 
-nav ul ul a, nav ul ul a:active {
-    font-family: 'bt_mono', monospace;
-    font-size: 14px;
-    padding-left: 20px;
-    padding-top: 3px;
-    padding-bottom: 9px;
+nav ul ul a,
+nav ul ul a:active {
+  font-family: 'bt_mono', monospace;
+  font-size: 14px;
+  padding-left: 20px;
+  padding-top: 3px;
+  padding-bottom: 9px;
 }
 
 nav h2 {
-    font-size: 12px;
-    margin: 0;
-    padding: 0;
+  font-size: 12px;
+  margin: 0;
+  padding: 0;
 }
 
 nav>h2>a {
-    color: hsl(202, 71%, 50%);
-    border-bottom: 1px solid hsl(202, 71%, 50%);
-    padding-bottom: 5px;
+  color: hsl(202, 71%, 50%);
+  border-bottom: 1px solid hsl(202, 71%, 50%);
+  padding-bottom: 5px;
 }
 
 nav>h2>a:hover {
-    font-weight: 500;
-    text-decoration: none;
+  font-weight: 500;
+  text-decoration: none;
 }
 
 footer {
-    background-color: #fff;
-    color: hsl(0, 0%, 28%);
-    margin-left: 300px;
-    display: block;
-    font-style: italic;
-    font-size: 12px;
-    padding: 30px;
-    text-align: center;
+  background-color: #fff;
+  color: hsl(0, 0%, 28%);
+  margin-left: 300px;
+  display: block;
+  font-style: italic;
+  font-size: 12px;
+  padding: 30px;
+  text-align: center;
 }
 
 .ancestors {
-    color: #999;
+  color: #999;
 }
 
 .ancestors a {
-    color: #999 !important;
-    text-decoration: none;
+  color: #999 !important;
+  text-decoration: none;
 }
 
 .clear {
-    clear: both;
+  clear: both;
 }
 
 .important {
-    font-weight: bold;
-    color: #950B02;
+  font-weight: bold;
+  color: #950B02;
 }
 
 .yes-def {
-    text-indent: -1000px;
+  text-indent: -1000px;
 }
 
 .type-signature {
-    color: #aaa;
+  color: #aaa;
 }
 
-.name, .signature {
-    font-family: 'bt_mono', monospace;
-    word-wrap: break-word;
+.name,
+.signature {
+  font-family: 'bt_mono', monospace;
+  word-wrap: break-word;
 }
 
 .details {
-    margin-top: 14px;
-    font-size: 13px;
-    text-align: right;
-    background: #ffffff;
-    /* Old browsers */
-    background: -moz-linear-gradient(left, #ffffff 0%, #fafafa 100%);
-    /* FF3.6-15 */
-    background: -webkit-linear-gradient(left, #ffffff 0%, #fafafa 100%);
-    /* Chrome10-25,Safari5.1-6 */
-    background: linear-gradient(to right, #ffffff 0%, #fafafa 100%);
-    /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
-    filter: progid: DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#fafafa', GradientType=1);
-    padding-right: 5px;
+  margin-top: 14px;
+  font-size: 13px;
+  text-align: right;
+  background: #ffffff;
+  /* Old browsers */
+  background: -moz-linear-gradient(left, #ffffff 0%, #fafafa 100%);
+  /* FF3.6-15 */
+  background: -webkit-linear-gradient(left, #ffffff 0%, #fafafa 100%);
+  /* Chrome10-25,Safari5.1-6 */
+  background: linear-gradient(to right, #ffffff 0%, #fafafa 100%);
+  /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+  filter: progid: DXImageTransform.Microsoft.gradient(startColorstr='#ffffff', endColorstr='#fafafa', GradientType=1);
+  padding-right: 5px;
 }
 
 .details dt {
-    display: inline-block;
+  display: inline-block;
 }
 
 .details dd {
-    display: inline-block;
-    margin: 0;
+  display: inline-block;
+  margin: 0;
 }
 
 .details dd a {
-    font-style: italic;
-    font-weight: normal;
-    line-height: 1;
+  font-style: italic;
+  font-weight: normal;
+  line-height: 1;
 }
 
 .details ul {
-    list-style-type: none;
-    margin: 0;
+  list-style-type: none;
+  margin: 0;
 }
 
 .details pre.prettyprint {
-    margin: 0
+  margin: 0
 }
 
 .details .object-value {
-    padding-top: 0
+  padding-top: 0
 }
 
 .description {
-    margin-bottom: 1em;
-    margin-top: 1em;
+  margin-bottom: 1em;
+  margin-top: 1em;
 }
 
 .code-caption {
-    font-style: italic;
-    margin: 0;
-    font-size: 16px;
-    color: #545454;
+  font-style: italic;
+  margin: 0;
+  font-size: 16px;
+  color: #545454;
 }
 
 .prettyprint {
-    font-size: 13px;
-    border: 1px solid #ddd;
-    border-radius: 3px;
-    overflow: auto;
-    background-color: #fbfbfb;
+  font-size: 13px;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  overflow: auto;
+  background-color: #fbfbfb;
 }
 
 .prettyprint.source {
-    width: inherit;
+  width: inherit;
 }
 
 .prettyprint code {
-    font-size: 100%;
-    line-height: 18px;
-    display: block;
-    margin: 0 30px;
-    background-color: #fbfbfb;
-    color: #4D4E53;
+  font-size: 100%;
+  line-height: 18px;
+  display: block;
+  margin: 0 30px;
+  background-color: #fbfbfb;
+  color: #4D4E53;
 }
 
 .prettyprint>code {
-    padding: 30px 15px;
+  padding: 30px 15px;
 }
 
 .prettyprint .linenums code {
-    padding: 0 15px;
+  padding: 0 15px;
 }
 
 .prettyprint .linenums li:first-of-type code {
-    padding-top: 15px;
+  padding-top: 15px;
 }
 
 .prettyprint code span.line {
-    display: inline-block;
+  display: inline-block;
 }
 
 .prettyprint.linenums {
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .prettyprint.linenums ol {
-    padding-left: 0
+  padding-left: 0
 }
 
 .prettyprint.linenums li {
-    border-left: 3px #ddd solid
+  border-left: 3px #ddd solid
 }
 
-.prettyprint.linenums li.selected, .prettyprint.linenums li.selected * {
-    background-color: lightyellow
+.prettyprint.linenums li.selected,
+.prettyprint.linenums li.selected * {
+  background-color: lightyellow
 }
 
 .prettyprint.linenums li * {
-    -webkit-user-select: text;
-    -moz-user-select: text;
-    -ms-user-select: text;
-    user-select: text;
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
 }
 
 .readme .prettyprint {
-   max-width: 800px;
+  max-width: 800px;
 }
 
-.params, .props {
-    border-spacing: 0;
-    border: 1px solid #ddd;
-    border-radius: 3px;
-    width: 100%;
-    font-size: 14px;
+.params,
+.returns,
+.props {
+  border-spacing: 0;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  width: 100%;
+  font-size: 14px;
 }
 
-.params .name, .props .name, .name code {
-    color: #4D4E53;
-    font-family: 'bt_mono', monospace;
-    font-size: 100%;
+.params .name,
+.props .name,
+.name code {
+  color: #4D4E53;
+  font-family: 'bt_mono', monospace;
+  font-size: 100%;
 }
 
-.params td, .params th, .props td, .props th {
-    margin: 0px;
-    text-align: left;
-    vertical-align: top;
-    padding: 10px;
-    display: table-cell;
+.params td,
+.params th,
+.returns td,
+.returns th,
+.props td,
+.props th {
+  margin: 0px;
+  text-align: left;
+  vertical-align: top;
+  padding: 10px;
+  display: table-cell;
 }
 
-.params td {
-    border-top: 1px solid #eee;
+.params td,
+.return td {
+  border-top: 1px solid #eee;
 }
 
-.params thead tr, .props thead tr {
-    background-color: #fff;
-    font-weight: bold;
+.params thead tr,
+.returns thead tr,
+.props thead tr {
+  background-color: #fff;
+  font-weight: bold;
 }
 
-.params .params thead tr, .props .props thead tr {
-    background-color: #fff;
-    font-weight: bold;
+.params .params thead tr,
+.returns .returns thead tr,
+.props .props thead tr {
+  background-color: #fff;
+  font-weight: bold;
 }
 
-.params td.description>p:first-child, .props td.description>p:first-child {
-    margin-top: 0;
-    padding-top: 0;
+.params td.description>p:first-child,
+.returns td.description>p:first-child,
+.props td.description>p:first-child {
+  margin-top: 0;
+  padding-top: 0;
 }
 
-.params td.description>p:last-child, .props td.description>p:last-child {
-    margin-bottom: 0;
-    padding-bottom: 0;
+.params td.description>p:last-child,
+.returns td.description>p:last-child,
+.props td.description>p:last-child {
+  margin-bottom: 0;
+  padding-bottom: 0;
 }
 
 dl.param-type {
-    margin-top: 5px;
+  margin-top: 5px;
 }
 
-.param-type dt, .param-type dd {
-    display: inline-block
+.param-type dt,
+.param-type dd {
+  display: inline-block
 }
 
 .param-type dd {
-    font-family: Consolas, Monaco, 'Andale Mono', monospace
+  font-family: Consolas, Monaco, 'Andale Mono', monospace
 }
 
 .disabled {
-    color: #454545
+  color: #454545
 }
 
 
@@ -574,307 +611,344 @@ dl.param-type {
 }
 
 .tag-source {
-    border-bottom: 1px solid rgba(28, 160, 224, 0.35);
+  border-bottom: 1px solid rgba(28, 160, 224, 0.35);
 }
 
 .tag-source:first-child {
-    border-bottom: 1px solid rgba(28, 160, 224, 1);
+  border-bottom: 1px solid rgba(28, 160, 224, 1);
 }
 
 
 /* navicon button */
 
 .navicon-button {
-    position: relative;
-    transition: 0.25s;
-    cursor: pointer;
-    user-select: none;
-    opacity: .8;
-    background-color: white;
-    border-radius: 100%;
-    width: 50px;
-    height: 50px;
-    -webkit-box-shadow: 0px 2px 9px 0px rgba(0, 0, 0, 0.31);
-    -moz-box-shadow: 0px 2px 9px 0px rgba(0, 0, 0, 0.31);
-    box-shadow: 0px 2px 9px 0px rgba(0, 0, 0, 0.31);
+  position: relative;
+  transition: 0.25s;
+  cursor: pointer;
+  user-select: none;
+  opacity: .8;
+  background-color: white;
+  border-radius: 100%;
+  width: 50px;
+  height: 50px;
+  -webkit-box-shadow: 0px 2px 9px 0px rgba(0, 0, 0, 0.31);
+  -moz-box-shadow: 0px 2px 9px 0px rgba(0, 0, 0, 0.31);
+  box-shadow: 0px 2px 9px 0px rgba(0, 0, 0, 0.31);
 }
 
-.navicon-button .navicon:before, .navicon-button .navicon:after {
-    transition: 0.25s;
+.navicon-button .navicon:before,
+.navicon-button .navicon:after {
+  transition: 0.25s;
 }
 
 .navicon-button:hover {
-    transition: 0.5s;
-    opacity: 1;
+  transition: 0.5s;
+  opacity: 1;
 }
 
-.navicon-button:hover .navicon:before, .navicon-button:hover .navicon:after {
-    transition: 0.25s;
+.navicon-button:hover .navicon:before,
+.navicon-button:hover .navicon:after {
+  transition: 0.25s;
 }
 
 .navicon-button:hover .navicon:before {
-    top: .425rem;
+  top: .425rem;
 }
 
 .navicon-button:hover .navicon:after {
-    top: -.425rem;
+  top: -.425rem;
 }
 
 
 /* navicon */
 
 .navicon {
-    position: relative;
-    width: 1.5em;
-    height: .195rem;
-    background: #000;
-    top: calc(50% - .09rem);
-    left: calc(50% - .75rem);
-    transition: 0.3s;
-    border-radius: 5px;
+  position: relative;
+  width: 1.5em;
+  height: .195rem;
+  background: #000;
+  top: calc(50% - .09rem);
+  left: calc(50% - .75rem);
+  transition: 0.3s;
+  border-radius: 5px;
 }
 
-.navicon:before, .navicon:after {
-    display: block;
-    content: "";
-    height: .195rem;
-    width: 1.5rem;
-    background: #000;
-    position: absolute;
-    z-index: -1;
-    transition: 0.3s 0.25s;
+.navicon:before,
+.navicon:after {
+  display: block;
+  content: "";
+  height: .195rem;
+  width: 1.5rem;
+  background: #000;
+  position: absolute;
+  z-index: -1;
+  transition: 0.3s 0.25s;
 }
 
 .navicon:before {
-    top: 0.425rem;
-    height: .195rem;
-    border-radius: 5px;
+  top: 0.425rem;
+  height: .195rem;
+  border-radius: 5px;
 }
 
 .navicon:after {
-    top: -0.425rem;
-    border-radius: 5px;
+  top: -0.425rem;
+  border-radius: 5px;
 }
 
 
 /* open */
 
-.nav-trigger:checked+label:not(.steps) .navicon:before, .nav-trigger:checked+label:not(.steps) .navicon:after {
-    top: 0 !important;
+.nav-trigger:checked+label:not(.steps) .navicon:before,
+.nav-trigger:checked+label:not(.steps) .navicon:after {
+  top: 0 !important;
 }
 
-.nav-trigger:checked+label .navicon:before, .nav-trigger:checked+label .navicon:after {
-    transition: 0.5s;
+.nav-trigger:checked+label .navicon:before,
+.nav-trigger:checked+label .navicon:after {
+  transition: 0.5s;
 }
 
 
 /* Minus */
 
 .nav-trigger:checked+label {
-    transform: scale(0.75);
+  transform: scale(0.75);
 }
 
 
 /* × and + */
 
-.nav-trigger:checked+label.plus .navicon, .nav-trigger:checked+label.x .navicon {
-    background: transparent;
+.nav-trigger:checked+label.plus .navicon,
+.nav-trigger:checked+label.x .navicon {
+  background: transparent;
 }
 
-.nav-trigger:checked+label.plus .navicon:before, .nav-trigger:checked+label.x .navicon:before {
-    transform: rotate(-45deg);
-    background: #000;
+.nav-trigger:checked+label.plus .navicon:before,
+.nav-trigger:checked+label.x .navicon:before {
+  transform: rotate(-45deg);
+  background: #000;
 }
 
-.nav-trigger:checked+label.plus .navicon:after, .nav-trigger:checked+label.x .navicon:after {
-    transform: rotate(45deg);
-    background: #000;
+.nav-trigger:checked+label.plus .navicon:after,
+.nav-trigger:checked+label.x .navicon:after {
+  transform: rotate(45deg);
+  background: #000;
 }
 
 .nav-trigger:checked+label.plus {
-    transform: scale(0.75) rotate(45deg);
+  transform: scale(0.75) rotate(45deg);
 }
 
 .nav-trigger:checked~nav {
-    left: 0 !important;
+  left: 0 !important;
 }
 
 .nav-trigger:checked~.overlay {
-    display: block;
+  display: block;
 }
 
 .nav-trigger {
-    position: fixed;
-    top: 0;
-    clip: rect(0, 0, 0, 0);
+  position: fixed;
+  top: 0;
+  clip: rect(0, 0, 0, 0);
 }
 
 .overlay {
-    display: none;
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    width: 100%;
-    height: 100%;
-    background: hsla(0, 0%, 0%, 0.5);
-    z-index: 1;
+  display: none;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+  background: hsla(0, 0%, 0%, 0.5);
+  z-index: 1;
 }
 
 table {
-    border-collapse: separate;
-    ;
-    display: block;
-    overflow-x: auto;
-    /*table-layout:fixed;*/
+  border-collapse: separate;
+  ;
+  display: block;
+  overflow-x: auto;
+  /*table-layout:fixed;*/
 }
 
 table tbody td {
-    border-top: 1px solid hsl(207, 10%, 86%);
-    border-right: 1px solid #eee;
-    padding: 5px;
-    /*word-wrap: break-word;*/
+  border-top: 1px solid hsl(207, 10%, 86%);
+  border-right: 1px solid #eee;
+  padding: 5px;
+  /*word-wrap: break-word;*/
 }
 
-td table.params, td table.props {
-    border: 0;
+td table.params,
+td table.props,
+td table.returns {
+  border: 0;
 }
 
 @media only screen and (min-width: 320px) and (max-width: 680px) {
-    body {
-        overflow-x: hidden;
-    }
-    #main {
-        padding: 30px 30px;
-        width: 100%;
-        min-width: 360px;
-    }
-    nav {
-        background: #FFF;
-        width: 300px;
-        height: 100%;
-        position: fixed;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: -300px;
-        z-index: 3;
-        padding: 0 10px;
-        transition: left 0.2s;
-        margin-top: 0;
-    }
-    .navicon-button {
-        display: inline-block;
-        position: fixed;
-        bottom: 1.5em;
-        right: 20px;
-        z-index: 1000;
-    }
-    .top-nav-wrapper {
-        display: none;
-    }
-    #main h1.page-title {
-        margin: 0.5em 0;
-    }
-    footer {
-        margin-left: 0;
-        margin-bottom: 30px;
-    }
+  body {
+    overflow-x: hidden;
+  }
+
+  #main {
+    padding: 30px 30px;
+    width: 100%;
+    min-width: 360px;
+  }
+
+  nav {
+    background: #FFF;
+    width: 300px;
+    height: 100%;
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: -300px;
+    z-index: 3;
+    padding: 0 10px;
+    transition: left 0.2s;
+    margin-top: 0;
+  }
+
+  .navicon-button {
+    display: inline-block;
+    position: fixed;
+    bottom: 1.5em;
+    right: 20px;
+    z-index: 1000;
+  }
+
+  .top-nav-wrapper {
+    display: none;
+  }
+
+  #main h1.page-title {
+    margin: 0.5em 0;
+  }
+
+  footer {
+    margin-left: 0;
+    margin-bottom: 30px;
+  }
 }
 
 .top-nav-wrapper {
-    background-color: #ececec;
-    position: fixed;
-    top: 0px;
-    left: 0px;
-    padding: 10px 10px 0 10px;
-    z-index: 999;
-    width: 300px;
+  background-color: #ececec;
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  padding: 10px 10px 0 10px;
+  z-index: 999;
+  width: 300px;
 }
 
 .top-nav-wrapper ul {
-    margin: 0;
+  margin: 0;
 }
 
 .top-nav-wrapper ul li {
-    display: inline-block;
-    padding: 0 10px;
-    vertical-align: top;
+  display: inline-block;
+  padding: 0 10px;
+  vertical-align: top;
 }
 
 .top-nav-wrapper ul li.active {
-    border-bottom: 2px solid rgba(28, 160, 224, 1);
+  border-bottom: 2px solid rgba(28, 160, 224, 1);
 }
 
 .search-wrapper {
-    display: inline-block;
-    position: relative;
+  display: inline-block;
+  position: relative;
 }
 
 .search-wrapper svg {
-    position: absolute;
-    left: 0px;
+  position: absolute;
+  left: 0px;
 }
 
 input.search-input {
-    background: transparent;
-    box-shadow: 0;
-    border: 0;
-    border-bottom: 1px solid #c7c7c7;
-    padding: 7px 15px 12px 35px;
-    margin: 0 auto;
+  background: transparent;
+  box-shadow: 0;
+  border: 0;
+  border-bottom: 1px solid #c7c7c7;
+  padding: 7px 15px 12px 35px;
+  margin: 0 auto;
 }
 
 
 /* Smooth outline with box-shadow: */
 
 input.search-input:focus {
-    border-bottom: 2px solid rgba(28, 160, 224, 1);
-    outline: none;
+  border-bottom: 2px solid rgba(28, 160, 224, 1);
+  outline: none;
 }
 
 
 /* Hightlight JS Paradiso Light Theme */
 
-.hljs-comment, .hljs-quote {
-    color: #776e71
+.hljs-comment,
+.hljs-quote {
+  color: #776e71
 }
 
-.hljs-variable, .hljs-template-variable, .hljs-tag, .hljs-name, .hljs-selector-id, .hljs-selector-class, .hljs-regexp, .hljs-link, .hljs-meta {
-    color: #ef6155
+.hljs-variable,
+.hljs-template-variable,
+.hljs-tag,
+.hljs-name,
+.hljs-selector-id,
+.hljs-selector-class,
+.hljs-regexp,
+.hljs-link,
+.hljs-meta {
+  color: #ef6155
 }
 
-.hljs-number, .hljs-built_in, .hljs-builtin-name, .hljs-literal, .hljs-type, .hljs-params, .hljs-deletion {
-    color: #f99b15
+.hljs-number,
+.hljs-built_in,
+.hljs-builtin-name,
+.hljs-literal,
+.hljs-type,
+.hljs-params,
+.hljs-deletion {
+  color: #f99b15
 }
 
-.hljs-title, .hljs-section, .hljs-attribute {
-    color: #fec418
+.hljs-title,
+.hljs-section,
+.hljs-attribute {
+  color: #fec418
 }
 
-.hljs-string, .hljs-symbol, .hljs-bullet, .hljs-addition {
-    color: #48b685
+.hljs-string,
+.hljs-symbol,
+.hljs-bullet,
+.hljs-addition {
+  color: #48b685
 }
 
-.hljs-keyword, .hljs-selector-tag {
-    color: #815ba4
+.hljs-keyword,
+.hljs-selector-tag {
+  color: #815ba4
 }
 
 .hljs {
-    display: block;
-    overflow-x: auto;
-    background: #e7e9db;
-    color: #4f424c;
-    padding: 0.5em
+  display: block;
+  overflow-x: auto;
+  background: #e7e9db;
+  color: #4f424c;
+  padding: 0.5em
 }
 
 .hljs-emphasis {
-    font-style: italic
+  font-style: italic
 }
 
 .hljs-strong {
-    font-weight: bold
+  font-weight: bold
 }
 
 .link-icon {

--- a/static/styles/jsdoc-default.css
+++ b/static/styles/jsdoc-default.css
@@ -1,606 +1,571 @@
 * {
-  box-sizing: border-box
+    box-sizing: border-box
 }
 
-html,
+html, body {
+    height: 100%;
+    width: 100%;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    color: #3e3c42;
+    text-rendering: optimizeLegibility;
+    margin: 0;
+}
+
 body {
-  height: 100%;
-  width: 100%;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  color: #3e3c42;
-  text-rendering: optimizeLegibility;
-  margin: 0;
+    color: #3e3c42;
+    background-color: #f3f3f3;
+    width: 100%;
+    font: 16px/1.875 "Avenir Next W01", "Avenir Next", "Helvetica Neue", Helvetica, sans-serif;
+    font-size: 16px;
+    line-height: 160%;
 }
 
-body {
-  color: #3e3c42;
-  background-color: #f3f3f3;
-  width: 100%;
-  font: 16px/1.875 "Avenir Next W01", "Avenir Next", "Helvetica Neue", Helvetica, sans-serif;
-  font-size: 16px;
-  line-height: 160%;
-}
-
-a,
-a:active {
-  color: #0095dd;
-  text-decoration: none;
+a, a:active {
+    color: #0095dd;
+    text-decoration: none;
 }
 
 a:hover {
-  text-decoration: underline
+    text-decoration: underline
 }
 
-p,
-ul,
-ol,
-blockquote {
-  margin-bottom: 1em;
+p, ul, ol, blockquote {
+    margin-bottom: 1em;
 }
 
 p {
-  max-width: 800px;
+    max-width: 800px;
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  color: #706d77;
-  font-weight: 500;
-  margin: 0;
-  line-height: 1;
+h1, h2, h3, h4, h5, h6 {
+    color: #706d77;
+    font-weight: 500;
+    margin: 0;
+    line-height: 1;
 }
 
 h1 {
-  color: #4b484f;
-  font-weight: 500;
-  font-size: 40px;
-  display: block;
+    color: #4b484f;
+    font-weight: 500;
+    font-size: 40px;
+    display: block;
 }
 
 h1 span {
-  color: #999;
-  font-size: 32px;
-  display: block;
-  line-height: 1.5;
+    color: #999;
+    font-size: 32px;
+    display: block;
+    line-height: 1.5;
 }
 
 h1.page-title {
-  border-bottom: 1px dashed #ccc;
-  margin-bottom: 20px;
-  padding-bottom: 30px;
+    border-bottom: 1px dashed #ccc;
+    margin-bottom: 20px;
+    padding-bottom: 30px;
 }
 
 h2 {
-  font-size: 30px;
-  margin: 1.5em 0 0;
+    font-size: 30px;
+    margin: 1.5em 0 0;
 }
 
 h3 {
-  font-size: 20px;
-  margin: 1.5em 0 0;
-  text-transform: uppercase;
+    font-size: 20px;
+    margin: 1.5em 0 0;
+    text-transform: uppercase;
 }
 
 h3.reference-title {
-  display: block;
-  font-weight: 400;
-  margin-top: 2em;
-  max-width: 200px;
+    display: block;
+    font-weight: 400;
+    margin-top: 2em;
+    max-width: 200px;
 }
 
 h3.reference-title small {
-  display: inline-block;
-  color: #0095dd;
-  margin-left: 5px;
-  font-weight: 500;
+    display: inline-block;
+    color: #0095dd;
+    margin-left: 5px;
+    font-weight: 500;
 }
 
 h3.subsection-title {
-  border-bottom: 1px solid #ececec;
-  padding-bottom: 20px;
-  margin-top: 3em;
-  margin-bottom: 1em;
+    border-bottom: 1px solid #ececec;
+    padding-bottom: 20px;
+    margin-top: 3em;
+    margin-bottom: 1em;
 }
 
 h4 {
-  font-size: 16px;
-  margin: 1em 0 0;
-  font-weight: bold;
+    font-size: 16px;
+    margin: 1em 0 0;
+    font-weight: bold;
 }
 
 h4.name {
-  font-size: 20px;
-  margin-top: 0;
-  font-weight: 500;
+    font-size: 20px;
+    margin-top: 0;
+    font-weight: 500;
 }
 
 h5 {
-  margin: 2em 0 0.5em 0;
-  font-size: 14px;
-  font-weight: 500;
-  text-transform: uppercase;
+    margin: 2em 0 0.5em 0;
+    font-size: 14px;
+    font-weight: 500;
+    text-transform: uppercase;
 }
 
 .container-overview .subsection-title {
-  font-size: 14px;
-  text-transform: uppercase;
-  margin: 8px 0 15px 0;
-  font-weight: bold;
-  color: #4D4E53;
-  padding-top: 10px;
+    font-size: 14px;
+    text-transform: uppercase;
+    margin: 8px 0 15px 0;
+    font-weight: bold;
+    color: #4D4E53;
+    padding-top: 10px;
 }
 
 h6 {
-  font-size: 100%;
-  letter-spacing: -0.01em;
-  margin: 6px 0 3px 0;
-  font-style: italic;
-  text-transform: uppercase;
-  font-weight: 500;
+    font-size: 100%;
+    letter-spacing: -0.01em;
+    margin: 6px 0 3px 0;
+    font-style: italic;
+    text-transform: uppercase;
+    font-weight: 500;
 }
 
-tt,
-code,
-kbd,
-samp {
-  font-family: "Source Code Pro", monospace;
-  background: #f4f4f4;
-  padding: 1px 5px;
-  border-radius: 5px;
+tt, code, kbd, samp {
+    font-family: "Source Code Pro", monospace;
+    background: #f4f4f4;
+    padding: 1px 5px;
+    border-radius: 5px;
 }
 
 .class-description {
-  margin-bottom: 1em;
-  margin-top: 1em;
-  padding: 10px 20px;
-  background-color: rgba(26, 159, 224, 0.1);
+    margin-bottom: 1em;
+    margin-top: 1em;
+    padding: 10px 20px;
+    background-color: rgba(26, 159, 224, 0.1);
 }
 
 .class-description:empty {
-  margin: 0
+    margin: 0
 }
 
 #main {
-  background-color: white;
-  float: right;
-  min-width: 360px;
-  width: calc(100% - 300px);
-  padding: 30px;
-  z-index: 100;
+    background-color: white;
+    float: right;
+    min-width: 360px;
+    width: calc(100% - 300px);
+    padding: 30px;
+    z-index: 100;
 }
 
 header {
-  display: block;
-  max-width: 1400px;
+    display: block;
+    max-width: 1400px;
 }
 
 section {
-  display: block;
-  max-width: 1400px;
-  background-color: #fff;
+    display: block;
+    max-width: 1400px;
+    background-color: #fff;
 }
 
 .variation {
-  display: none
+    display: none
 }
 
 .signature-attributes {
-  font-size: 60%;
-  color: #aaa;
-  font-style: italic;
-  font-weight: lighter;
+    font-size: 60%;
+    color: #aaa;
+    font-style: italic;
+    font-weight: lighter;
 }
 
 .rule {
-  width: 100%;
-  margin-top: 20px;
-  display: block;
-  border-top: 1px solid #ccc;
+    width: 100%;
+    margin-top: 20px;
+    display: block;
+    border-top: 1px solid #ccc;
 }
 
 ul {
-  list-style-type: none;
-  padding-left: 0;
+    list-style-type: none;
+    padding-left: 0;
 }
 
 ul li a {
-  font-weight: 500;
+    font-weight: 500;
 }
 
 ul ul {
-  padding-top: 5px;
+    padding-top: 5px;
 }
 
 ul li ul {
-  padding-left: 20px;
+    padding-left: 20px;
 }
 
 ul li ul li a {
-  font-weight: normal;
+    font-weight: normal;
 }
 
 nav {
-  float: left;
-  display: block;
-  width: 300px;
-  background: #f7f7f7;
-  overflow-x: visible;
-  overflow-y: auto;
-  height: 100%;
-  padding: 0px 30px 100px 30px;
-  height: 100%;
-  position: fixed;
-  transition: left 0.2s;
-  z-index: 998;
-  margin-top: 0px;
-  top: 43px;
+    float: left;
+    display: block;
+    width: 300px;
+    background: #f7f7f7;
+    overflow-x: visible;
+    overflow-y: auto;
+    height: 100%;
+    padding: 0px 30px 100px 30px;
+    height: 100%;
+    position: fixed;
+    transition: left 0.2s;
+    z-index: 998;
+    margin-top: 0px;
+    top: 43px;
 }
 
 .navicon-button {
-  display: inline-block;
-  position: fixed;
-  bottom: 1.5em;
-  right: 1.5em;
-  z-index: 2;
+    display: inline-block;
+    position: fixed;
+    bottom: 1.5em;
+    right: 1.5em;
+    z-index: 2;
 }
 
 nav h3 {
-  font-size: 13px;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  font-weight: bold;
-  line-height: 24px;
-  margin: 40px 0 10px 0;
-  padding: 0;
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-weight: bold;
+    line-height: 24px;
+    margin: 40px 0 10px 0;
+    padding: 0;
 }
 
 nav ul {
-  font-size: 100%;
-  line-height: 17px;
-  padding: 0;
-  margin: 0;
-  list-style-type: none;
-  border: none;
-  padding-left: 0;
+    font-size: 100%;
+    line-height: 17px;
+    padding: 0;
+    margin: 0;
+    list-style-type: none;
+    border: none;
+    padding-left: 0;
 }
 
 nav ul a {
-  font-size: 16px;
+    font-size: 16px;
 }
 
-nav ul a,
-nav ul a:active {
-  display: block;
+nav ul a, nav ul a:active {
+    display: block;
 }
 
-nav ul a:hover,
-nav ul a:active {
-  color: hsl(200, 100%, 43%);
-  text-decoration: none;
+nav ul a:hover, nav ul a:active {
+    color: hsl(200, 100%, 43%);
+    text-decoration: none;
 }
 
 nav>ul {
-  padding: 0 10px;
+    padding: 0 10px;
 }
 
 nav>ul li:first-child {
-  padding-top: 0;
+    padding-top: 0;
 }
 
 nav ul li ul {
-  padding-left: 0;
+    padding-left: 0;
 }
 
 nav>ul>li {
-  border-bottom: 1px solid #e2e2e2;
-  padding: 10px 0 20px 0;
+    border-bottom: 1px solid #e2e2e2;
+    padding: 10px 0 20px 0;
 }
 
 nav>ul>li.active ul {
-  border-left: 3px solid #0095dd;
-  padding-left: 15px;
+    border-left: 3px solid #0095dd;
+    padding-left: 15px;
 }
 
 nav>ul>li.active ul li.active a {
-  font-weight: bold;
+    font-weight: bold;
 }
 
 nav>ul>li.active a {
-  color: #0095dd;
+    color: #0095dd;
 }
 
 nav>ul>li>a {
-  color: #706d77;
-  padding: 20px 0;
-  font-size: 18px;
+    color: #706d77;
+    padding: 20px 0;
+    font-size: 18px;
 }
 
 nav ul ul {
-  margin-bottom: 10px;
-  padding-left: 0;
+    margin-bottom: 10px;
+    padding-left: 0;
 }
 
 nav ul ul a {
-  color: #5f5c63;
+    color: #5f5c63;
 }
 
-nav ul ul a,
-nav ul ul a:active {
-  font-family: 'bt_mono', monospace;
-  font-size: 14px;
-  padding-left: 20px;
-  padding-top: 3px;
-  padding-bottom: 9px;
+nav ul ul a, nav ul ul a:active {
+    font-family: 'bt_mono', monospace;
+    font-size: 14px;
+    padding-left: 20px;
+    padding-top: 3px;
+    padding-bottom: 9px;
 }
 
 nav h2 {
-  font-size: 12px;
-  margin: 0;
-  padding: 0;
+    font-size: 12px;
+    margin: 0;
+    padding: 0;
 }
 
 nav>h2>a {
-  color: hsl(202, 71%, 50%);
-  border-bottom: 1px solid hsl(202, 71%, 50%);
-  padding-bottom: 5px;
+    color: hsl(202, 71%, 50%);
+    border-bottom: 1px solid hsl(202, 71%, 50%);
+    padding-bottom: 5px;
 }
 
 nav>h2>a:hover {
-  font-weight: 500;
-  text-decoration: none;
+    font-weight: 500;
+    text-decoration: none;
 }
 
 footer {
-  background-color: #fff;
-  color: hsl(0, 0%, 28%);
-  margin-left: 300px;
-  display: block;
-  font-style: italic;
-  font-size: 12px;
-  padding: 30px;
-  text-align: center;
+    background-color: #fff;
+    color: hsl(0, 0%, 28%);
+    margin-left: 300px;
+    display: block;
+    font-style: italic;
+    font-size: 12px;
+    padding: 30px;
+    text-align: center;
 }
 
 .ancestors {
-  color: #999;
+    color: #999;
 }
 
 .ancestors a {
-  color: #999 !important;
-  text-decoration: none;
+    color: #999 !important;
+    text-decoration: none;
 }
 
 .clear {
-  clear: both;
+    clear: both;
 }
 
 .important {
-  font-weight: bold;
-  color: #950B02;
+    font-weight: bold;
+    color: #950B02;
 }
 
 .yes-def {
-  text-indent: -1000px;
+    text-indent: -1000px;
 }
 
 .type-signature {
-  color: #aaa;
+    color: #aaa;
 }
 
-.name,
-.signature {
-  font-family: 'bt_mono', monospace;
-  word-wrap: break-word;
+.name, .signature {
+    font-family: 'bt_mono', monospace;
+    word-wrap: break-word;
 }
 
 .details {
-  margin-top: 14px;
-  font-size: 13px;
-  text-align: right;
-  background: #ffffff;
-  /* Old browsers */
-  background: -moz-linear-gradient(left, #ffffff 0%, #fafafa 100%);
-  /* FF3.6-15 */
-  background: -webkit-linear-gradient(left, #ffffff 0%, #fafafa 100%);
-  /* Chrome10-25,Safari5.1-6 */
-  background: linear-gradient(to right, #ffffff 0%, #fafafa 100%);
-  /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
-  filter: progid: DXImageTransform.Microsoft.gradient(startColorstr='#ffffff', endColorstr='#fafafa', GradientType=1);
-  padding-right: 5px;
+    margin-top: 14px;
+    font-size: 13px;
+    text-align: right;
+    background: #ffffff;
+    /* Old browsers */
+    background: -moz-linear-gradient(left, #ffffff 0%, #fafafa 100%);
+    /* FF3.6-15 */
+    background: -webkit-linear-gradient(left, #ffffff 0%, #fafafa 100%);
+    /* Chrome10-25,Safari5.1-6 */
+    background: linear-gradient(to right, #ffffff 0%, #fafafa 100%);
+    /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+    filter: progid: DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#fafafa', GradientType=1);
+    padding-right: 5px;
 }
 
 .details dt {
-  display: inline-block;
+    display: inline-block;
 }
 
 .details dd {
-  display: inline-block;
-  margin: 0;
+    display: inline-block;
+    margin: 0;
 }
 
 .details dd a {
-  font-style: italic;
-  font-weight: normal;
-  line-height: 1;
+    font-style: italic;
+    font-weight: normal;
+    line-height: 1;
 }
 
 .details ul {
-  list-style-type: none;
-  margin: 0;
+    list-style-type: none;
+    margin: 0;
 }
 
 .details pre.prettyprint {
-  margin: 0
+    margin: 0
 }
 
 .details .object-value {
-  padding-top: 0
+    padding-top: 0
 }
 
 .description {
-  margin-bottom: 1em;
-  margin-top: 1em;
+    margin-bottom: 1em;
+    margin-top: 1em;
 }
 
 .code-caption {
-  font-style: italic;
-  margin: 0;
-  font-size: 16px;
-  color: #545454;
+    font-style: italic;
+    margin: 0;
+    font-size: 16px;
+    color: #545454;
 }
 
 .prettyprint {
-  font-size: 13px;
-  border: 1px solid #ddd;
-  border-radius: 3px;
-  overflow: auto;
-  background-color: #fbfbfb;
+    font-size: 13px;
+    border: 1px solid #ddd;
+    border-radius: 3px;
+    overflow: auto;
+    background-color: #fbfbfb;
 }
 
 .prettyprint.source {
-  width: inherit;
+    width: inherit;
 }
 
 .prettyprint code {
-  font-size: 100%;
-  line-height: 18px;
-  display: block;
-  margin: 0 30px;
-  background-color: #fbfbfb;
-  color: #4D4E53;
+    font-size: 100%;
+    line-height: 18px;
+    display: block;
+    margin: 0 30px;
+    background-color: #fbfbfb;
+    color: #4D4E53;
 }
 
 .prettyprint>code {
-  padding: 30px 15px;
+    padding: 30px 15px;
 }
 
 .prettyprint .linenums code {
-  padding: 0 15px;
+    padding: 0 15px;
 }
 
 .prettyprint .linenums li:first-of-type code {
-  padding-top: 15px;
+    padding-top: 15px;
 }
 
 .prettyprint code span.line {
-  display: inline-block;
+    display: inline-block;
 }
 
 .prettyprint.linenums {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 
 .prettyprint.linenums ol {
-  padding-left: 0
+    padding-left: 0
 }
 
 .prettyprint.linenums li {
-  border-left: 3px #ddd solid
+    border-left: 3px #ddd solid
 }
 
-.prettyprint.linenums li.selected,
-.prettyprint.linenums li.selected * {
-  background-color: lightyellow
+.prettyprint.linenums li.selected, .prettyprint.linenums li.selected * {
+    background-color: lightyellow
 }
 
 .prettyprint.linenums li * {
-  -webkit-user-select: text;
-  -moz-user-select: text;
-  -ms-user-select: text;
-  user-select: text;
+    -webkit-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
+    user-select: text;
 }
 
 .readme .prettyprint {
-  max-width: 800px;
+   max-width: 800px;
 }
 
 .params,
 .returns,
 .props {
-  border-spacing: 0;
-  border: 1px solid #ddd;
-  border-radius: 3px;
-  width: 100%;
-  font-size: 14px;
+    border-spacing: 0;
+    border: 1px solid #ddd;
+    border-radius: 3px;
+    width: 100%;
+    font-size: 14px;
 }
 
-.params .name,
-.props .name,
-.name code {
-  color: #4D4E53;
-  font-family: 'bt_mono', monospace;
-  font-size: 100%;
+.params .name, .props .name, .name code {
+    color: #4D4E53;
+    font-family: 'bt_mono', monospace;
+    font-size: 100%;
 }
 
-.params td,
-.params th,
-.returns td,
-.returns th,
-.props td,
-.props th {
-  margin: 0px;
-  text-align: left;
-  vertical-align: top;
-  padding: 10px;
-  display: table-cell;
+.params td, .params th,.returns td, .returns th, .props td, .props th {
+    margin: 0px;
+    text-align: left;
+    vertical-align: top;
+    padding: 10px;
+    display: table-cell;
 }
 
-.params td,
-.return td {
-  border-top: 1px solid #eee;
+.params td, .returns td {
+    border-top: 1px solid #eee;
 }
 
-.params thead tr,
-.returns thead tr,
-.props thead tr {
-  background-color: #fff;
-  font-weight: bold;
+.params thead tr, .returns thead tr,.props thead tr {
+    background-color: #fff;
+    font-weight: bold;
 }
 
-.params .params thead tr,
-.returns .returns thead tr,
-.props .props thead tr {
-  background-color: #fff;
-  font-weight: bold;
+.params .params thead tr, .returns .returns thead tr, .props .props thead tr {
+    background-color: #fff;
+    font-weight: bold;
 }
 
-.params td.description>p:first-child,
-.returns td.description>p:first-child,
-.props td.description>p:first-child {
-  margin-top: 0;
-  padding-top: 0;
+.params td.description>p:first-child, .returns td.description>p:first-child, .props td.description>p:first-child {
+    margin-top: 0;
+    padding-top: 0;
 }
 
-.params td.description>p:last-child,
-.returns td.description>p:last-child,
-.props td.description>p:last-child {
-  margin-bottom: 0;
-  padding-bottom: 0;
+.params td.description>p:last-child, .returns td.description>p:last-child, .props td.description>p:last-child {
+    margin-bottom: 0;
+    padding-bottom: 0;
 }
 
 dl.param-type {
-  margin-top: 5px;
+    margin-top: 5px;
 }
 
-.param-type dt,
-.param-type dd {
-  display: inline-block
+.param-type dt, .param-type dd {
+    display: inline-block
 }
 
 .param-type dd {
-  font-family: Consolas, Monaco, 'Andale Mono', monospace
+    font-family: Consolas, Monaco, 'Andale Mono', monospace
 }
 
 .disabled {
-  color: #454545
+    color: #454545
 }
 
 
@@ -611,344 +576,307 @@ dl.param-type {
 }
 
 .tag-source {
-  border-bottom: 1px solid rgba(28, 160, 224, 0.35);
+    border-bottom: 1px solid rgba(28, 160, 224, 0.35);
 }
 
 .tag-source:first-child {
-  border-bottom: 1px solid rgba(28, 160, 224, 1);
+    border-bottom: 1px solid rgba(28, 160, 224, 1);
 }
 
 
 /* navicon button */
 
 .navicon-button {
-  position: relative;
-  transition: 0.25s;
-  cursor: pointer;
-  user-select: none;
-  opacity: .8;
-  background-color: white;
-  border-radius: 100%;
-  width: 50px;
-  height: 50px;
-  -webkit-box-shadow: 0px 2px 9px 0px rgba(0, 0, 0, 0.31);
-  -moz-box-shadow: 0px 2px 9px 0px rgba(0, 0, 0, 0.31);
-  box-shadow: 0px 2px 9px 0px rgba(0, 0, 0, 0.31);
+    position: relative;
+    transition: 0.25s;
+    cursor: pointer;
+    user-select: none;
+    opacity: .8;
+    background-color: white;
+    border-radius: 100%;
+    width: 50px;
+    height: 50px;
+    -webkit-box-shadow: 0px 2px 9px 0px rgba(0, 0, 0, 0.31);
+    -moz-box-shadow: 0px 2px 9px 0px rgba(0, 0, 0, 0.31);
+    box-shadow: 0px 2px 9px 0px rgba(0, 0, 0, 0.31);
 }
 
-.navicon-button .navicon:before,
-.navicon-button .navicon:after {
-  transition: 0.25s;
+.navicon-button .navicon:before, .navicon-button .navicon:after {
+    transition: 0.25s;
 }
 
 .navicon-button:hover {
-  transition: 0.5s;
-  opacity: 1;
+    transition: 0.5s;
+    opacity: 1;
 }
 
-.navicon-button:hover .navicon:before,
-.navicon-button:hover .navicon:after {
-  transition: 0.25s;
+.navicon-button:hover .navicon:before, .navicon-button:hover .navicon:after {
+    transition: 0.25s;
 }
 
 .navicon-button:hover .navicon:before {
-  top: .425rem;
+    top: .425rem;
 }
 
 .navicon-button:hover .navicon:after {
-  top: -.425rem;
+    top: -.425rem;
 }
 
 
 /* navicon */
 
 .navicon {
-  position: relative;
-  width: 1.5em;
-  height: .195rem;
-  background: #000;
-  top: calc(50% - .09rem);
-  left: calc(50% - .75rem);
-  transition: 0.3s;
-  border-radius: 5px;
+    position: relative;
+    width: 1.5em;
+    height: .195rem;
+    background: #000;
+    top: calc(50% - .09rem);
+    left: calc(50% - .75rem);
+    transition: 0.3s;
+    border-radius: 5px;
 }
 
-.navicon:before,
-.navicon:after {
-  display: block;
-  content: "";
-  height: .195rem;
-  width: 1.5rem;
-  background: #000;
-  position: absolute;
-  z-index: -1;
-  transition: 0.3s 0.25s;
+.navicon:before, .navicon:after {
+    display: block;
+    content: "";
+    height: .195rem;
+    width: 1.5rem;
+    background: #000;
+    position: absolute;
+    z-index: -1;
+    transition: 0.3s 0.25s;
 }
 
 .navicon:before {
-  top: 0.425rem;
-  height: .195rem;
-  border-radius: 5px;
+    top: 0.425rem;
+    height: .195rem;
+    border-radius: 5px;
 }
 
 .navicon:after {
-  top: -0.425rem;
-  border-radius: 5px;
+    top: -0.425rem;
+    border-radius: 5px;
 }
 
 
 /* open */
 
-.nav-trigger:checked+label:not(.steps) .navicon:before,
-.nav-trigger:checked+label:not(.steps) .navicon:after {
-  top: 0 !important;
+.nav-trigger:checked+label:not(.steps) .navicon:before, .nav-trigger:checked+label:not(.steps) .navicon:after {
+    top: 0 !important;
 }
 
-.nav-trigger:checked+label .navicon:before,
-.nav-trigger:checked+label .navicon:after {
-  transition: 0.5s;
+.nav-trigger:checked+label .navicon:before, .nav-trigger:checked+label .navicon:after {
+    transition: 0.5s;
 }
 
 
 /* Minus */
 
 .nav-trigger:checked+label {
-  transform: scale(0.75);
+    transform: scale(0.75);
 }
 
 
 /* × and + */
 
-.nav-trigger:checked+label.plus .navicon,
-.nav-trigger:checked+label.x .navicon {
-  background: transparent;
+.nav-trigger:checked+label.plus .navicon, .nav-trigger:checked+label.x .navicon {
+    background: transparent;
 }
 
-.nav-trigger:checked+label.plus .navicon:before,
-.nav-trigger:checked+label.x .navicon:before {
-  transform: rotate(-45deg);
-  background: #000;
+.nav-trigger:checked+label.plus .navicon:before, .nav-trigger:checked+label.x .navicon:before {
+    transform: rotate(-45deg);
+    background: #000;
 }
 
-.nav-trigger:checked+label.plus .navicon:after,
-.nav-trigger:checked+label.x .navicon:after {
-  transform: rotate(45deg);
-  background: #000;
+.nav-trigger:checked+label.plus .navicon:after, .nav-trigger:checked+label.x .navicon:after {
+    transform: rotate(45deg);
+    background: #000;
 }
 
 .nav-trigger:checked+label.plus {
-  transform: scale(0.75) rotate(45deg);
+    transform: scale(0.75) rotate(45deg);
 }
 
 .nav-trigger:checked~nav {
-  left: 0 !important;
+    left: 0 !important;
 }
 
 .nav-trigger:checked~.overlay {
-  display: block;
+    display: block;
 }
 
 .nav-trigger {
-  position: fixed;
-  top: 0;
-  clip: rect(0, 0, 0, 0);
+    position: fixed;
+    top: 0;
+    clip: rect(0, 0, 0, 0);
 }
 
 .overlay {
-  display: none;
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  width: 100%;
-  height: 100%;
-  background: hsla(0, 0%, 0%, 0.5);
-  z-index: 1;
+    display: none;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    background: hsla(0, 0%, 0%, 0.5);
+    z-index: 1;
 }
 
 table {
-  border-collapse: separate;
-  ;
-  display: block;
-  overflow-x: auto;
-  /*table-layout:fixed;*/
+    border-collapse: separate;
+    ;
+    display: block;
+    overflow-x: auto;
+    /*table-layout:fixed;*/
 }
 
 table tbody td {
-  border-top: 1px solid hsl(207, 10%, 86%);
-  border-right: 1px solid #eee;
-  padding: 5px;
-  /*word-wrap: break-word;*/
+    border-top: 1px solid hsl(207, 10%, 86%);
+    border-right: 1px solid #eee;
+    padding: 5px;
+    /*word-wrap: break-word;*/
 }
 
-td table.params,
-td table.props,
-td table.returns {
-  border: 0;
+td table.params, td table.returns, td table.props {
+    border: 0;
 }
 
 @media only screen and (min-width: 320px) and (max-width: 680px) {
-  body {
-    overflow-x: hidden;
-  }
-
-  #main {
-    padding: 30px 30px;
-    width: 100%;
-    min-width: 360px;
-  }
-
-  nav {
-    background: #FFF;
-    width: 300px;
-    height: 100%;
-    position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: -300px;
-    z-index: 3;
-    padding: 0 10px;
-    transition: left 0.2s;
-    margin-top: 0;
-  }
-
-  .navicon-button {
-    display: inline-block;
-    position: fixed;
-    bottom: 1.5em;
-    right: 20px;
-    z-index: 1000;
-  }
-
-  .top-nav-wrapper {
-    display: none;
-  }
-
-  #main h1.page-title {
-    margin: 0.5em 0;
-  }
-
-  footer {
-    margin-left: 0;
-    margin-bottom: 30px;
-  }
+    body {
+        overflow-x: hidden;
+    }
+    #main {
+        padding: 30px 30px;
+        width: 100%;
+        min-width: 360px;
+    }
+    nav {
+        background: #FFF;
+        width: 300px;
+        height: 100%;
+        position: fixed;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: -300px;
+        z-index: 3;
+        padding: 0 10px;
+        transition: left 0.2s;
+        margin-top: 0;
+    }
+    .navicon-button {
+        display: inline-block;
+        position: fixed;
+        bottom: 1.5em;
+        right: 20px;
+        z-index: 1000;
+    }
+    .top-nav-wrapper {
+        display: none;
+    }
+    #main h1.page-title {
+        margin: 0.5em 0;
+    }
+    footer {
+        margin-left: 0;
+        margin-bottom: 30px;
+    }
 }
 
 .top-nav-wrapper {
-  background-color: #ececec;
-  position: fixed;
-  top: 0px;
-  left: 0px;
-  padding: 10px 10px 0 10px;
-  z-index: 999;
-  width: 300px;
+    background-color: #ececec;
+    position: fixed;
+    top: 0px;
+    left: 0px;
+    padding: 10px 10px 0 10px;
+    z-index: 999;
+    width: 300px;
 }
 
 .top-nav-wrapper ul {
-  margin: 0;
+    margin: 0;
 }
 
 .top-nav-wrapper ul li {
-  display: inline-block;
-  padding: 0 10px;
-  vertical-align: top;
+    display: inline-block;
+    padding: 0 10px;
+    vertical-align: top;
 }
 
 .top-nav-wrapper ul li.active {
-  border-bottom: 2px solid rgba(28, 160, 224, 1);
+    border-bottom: 2px solid rgba(28, 160, 224, 1);
 }
 
 .search-wrapper {
-  display: inline-block;
-  position: relative;
+    display: inline-block;
+    position: relative;
 }
 
 .search-wrapper svg {
-  position: absolute;
-  left: 0px;
+    position: absolute;
+    left: 0px;
 }
 
 input.search-input {
-  background: transparent;
-  box-shadow: 0;
-  border: 0;
-  border-bottom: 1px solid #c7c7c7;
-  padding: 7px 15px 12px 35px;
-  margin: 0 auto;
+    background: transparent;
+    box-shadow: 0;
+    border: 0;
+    border-bottom: 1px solid #c7c7c7;
+    padding: 7px 15px 12px 35px;
+    margin: 0 auto;
 }
 
 
 /* Smooth outline with box-shadow: */
 
 input.search-input:focus {
-  border-bottom: 2px solid rgba(28, 160, 224, 1);
-  outline: none;
+    border-bottom: 2px solid rgba(28, 160, 224, 1);
+    outline: none;
 }
 
 
 /* Hightlight JS Paradiso Light Theme */
 
-.hljs-comment,
-.hljs-quote {
-  color: #776e71
+.hljs-comment, .hljs-quote {
+    color: #776e71
 }
 
-.hljs-variable,
-.hljs-template-variable,
-.hljs-tag,
-.hljs-name,
-.hljs-selector-id,
-.hljs-selector-class,
-.hljs-regexp,
-.hljs-link,
-.hljs-meta {
-  color: #ef6155
+.hljs-variable, .hljs-template-variable, .hljs-tag, .hljs-name, .hljs-selector-id, .hljs-selector-class, .hljs-regexp, .hljs-link, .hljs-meta {
+    color: #ef6155
 }
 
-.hljs-number,
-.hljs-built_in,
-.hljs-builtin-name,
-.hljs-literal,
-.hljs-type,
-.hljs-params,
-.hljs-deletion {
-  color: #f99b15
+.hljs-number, .hljs-built_in, .hljs-builtin-name, .hljs-literal, .hljs-type, .hljs-params, .hljs-deletion {
+    color: #f99b15
 }
 
-.hljs-title,
-.hljs-section,
-.hljs-attribute {
-  color: #fec418
+.hljs-title, .hljs-section, .hljs-attribute {
+    color: #fec418
 }
 
-.hljs-string,
-.hljs-symbol,
-.hljs-bullet,
-.hljs-addition {
-  color: #48b685
+.hljs-string, .hljs-symbol, .hljs-bullet, .hljs-addition {
+    color: #48b685
 }
 
-.hljs-keyword,
-.hljs-selector-tag {
-  color: #815ba4
+.hljs-keyword, .hljs-selector-tag {
+    color: #815ba4
 }
 
 .hljs {
-  display: block;
-  overflow-x: auto;
-  background: #e7e9db;
-  color: #4f424c;
-  padding: 0.5em
+    display: block;
+    overflow-x: auto;
+    background: #e7e9db;
+    color: #4f424c;
+    padding: 0.5em
 }
 
 .hljs-emphasis {
-  font-style: italic
+    font-style: italic
 }
 
 .hljs-strong {
-  font-weight: bold
+    font-weight: bold
 }
 
 .link-icon {

--- a/tmpl/method.tmpl
+++ b/tmpl/method.tmpl
@@ -51,6 +51,11 @@
   <?js= this.partial('params.tmpl', params) ?>
 <?js } ?>
 
+<?js if (data.returns && returns.length) { ?>
+  <h5>Returns:</h5>
+  <?js= this.partial('returns.tmpl', returns) ?>
+<?js } ?>
+
 <?js= this.partial('details.tmpl', data) ?>
 
 <?js if (data.kind !== 'module' && data.requires && data.requires.length) { ?>
@@ -112,7 +117,7 @@
     exceptions.forEach(function(r) { ?>
       <?js= self.partial('exceptions.tmpl', r) ?>
     <?js });
-  } 
+  }
 } ?>
 
 <?js if (data.examples && examples.length) { ?>

--- a/tmpl/returns.tmpl
+++ b/tmpl/returns.tmpl
@@ -1,17 +1,33 @@
 <?js
-var data = obj || {};
-if (data.description) {
+var returns = obj;
 ?>
-  <div class="param-desc">
-    <?js= description ?>
-  </div>
-<?js } ?>
 
-<?js if (data.type && data.type.names) {?>
-  <dl class="param-type">
-    <dt>Type</dt>
-    <dd>
-      <?js= this.partial('type.tmpl', data.type.names) ?>
-    </dd>
-  </dl>
-<?js } ?>
+<table class="returns">
+  <thead>
+    <tr>
+      <th>Type</th>
+      <th class="last">Description</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <?js
+      var self = this;
+      returns.forEach(item => {
+        if (!item) { return; }
+    ?>
+      <tr>
+        <td class="type">
+          <?js if (item.type && item.type.names) {?>
+            <?js= self.partial('type.tmpl', item.type.names) ?>
+          <?js } ?>
+        </td>
+
+        <td class="description">
+          <?js= item.description ?>
+        </td>
+      </tr>
+    <?js }
+  ); ?>
+  </tbody>
+</table>


### PR DESCRIPTION
Problem: client library's generated document miss functions' returns description.

Cause: `returns.tmpl` has never been referred before.

Fix: 
1. Add `returns.tmpl` in `method.tmpl`
2. Use `<table>`  like params and propers to render returns

Result:
![image](https://user-images.githubusercontent.com/6378676/82383144-19a31c00-99e2-11ea-8979-470714fed626.png)
