### PR TITLE
feat: display deprecation messages better

### DIFF
--- a/tmpl/details.tmpl
+++ b/tmpl/details.tmpl
@@ -104,27 +104,6 @@
     </dd>
   <?js } ?>
 
-  <?js if (data.deprecated) { ?>
-    <dt class="important tag-deprecated">Deprecated:</dt>
-    <?js
-      if (data.deprecated === true) { ?>
-        <dd class="yes-def tag-deprecated">
-          <ul class="dummy">
-            <li>Yes</li>
-          </ul>
-        </dd>
-      <?js } else { ?>
-        <dd>
-          <ul class="dummy">
-            <li>
-              <?js= data.deprecated ?>
-            </li>
-          </ul>
-        </dd>
-      <?js } ?>
-    <br>
-  <?js } ?>
-
   <?js if (data.author && author.length) {?>
     <dt class="tag-author">Author:</dt>
     <dd class="tag-author">

--- a/tmpl/method.tmpl
+++ b/tmpl/method.tmpl
@@ -46,6 +46,13 @@
   </ul>
 <?js } ?>
 
+ <?js if (data.deprecated) { ?>
+    <div class="important tag-deprecated">Deprecated:
+      <?js= data.deprecated ?>
+    </div> 
+    <br>
+  <?js } ?>
+
 <?js if (data.params && params.length) { ?>
   <h5>Parameters:</h5>
   <?js= this.partial('params.tmpl', params) ?>


### PR DESCRIPTION
@alexander-fenster @summer-ji-eng @JustinBeckwith for visibility

Problem: Generated client libraries did not display deprecation messages in a prominent location

Cause: Deprecated tags were being read by the details.tmpl which is referenced below several other tables in the methods.templ file.

Fix:

Added reading of deprecated tags directly into methods.templ file to be right below the description of the method/service.
Removed the deprecated tags being read in the details.tmpl file.

Fixes #67  🦕
