### PR TITLE
fix(deps): replace `taffydb` with `@jsdoc/salty`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "taffydb": "^2.7.3"
+    "@jsdoc/salty": "^0.2.5"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/publish.js
+++ b/publish.js
@@ -8,7 +8,7 @@ const fs = require('jsdoc/fs');
 const helper = require('jsdoc/util/templateHelper');
 const logger = require('jsdoc/util/logger');
 const path = require('jsdoc/path');
-const taffy = require('taffydb').taffy;
+const taffy = require('@jsdoc/salty').taffy;
 const template = require('jsdoc/template');
 const util = require('util');
 


### PR DESCRIPTION
The `taffydb` package has issues. It's unclear what license it uses, and it has an alleged "security vulnerability" that's completely bogus but nonetheless causes `npm audit` to squawk. See https://github.com/jsdoc/jsdoc/blob/main/packages/jsdoc-salty/README.md for details about both issues.

This PR replaces `taffydb` with `@jsdoc/salty`, a drop-in replacement for `taffydb` that's licensed under the Apache License 2.0. It has no known security issues, bogus or otherwise.

To test this PR, I generated docs for JSDoc 4.x using this template:

```
git clone https://github.com/jsdoc/jsdoc
cd jsdoc
git checkout releases/4.0
npm install
node jsdoc.js jsdoc.js lib/jsdoc/* -t ../jsdoc-fresh
```

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com//issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)